### PR TITLE
ci: Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+      prod-dependencies:
+        dependency-type: "production"
+        update-types:
+        - "patch"
+        - "minor"


### PR DESCRIPTION
I figured this addition was actually best for a separate PR, so I removed the file from #11 (72f9f65).

A `.github/dependabot.yml` configures the GitHub Dependabot to automatically create PRs for updating dependencies. This is a good practice to keep dependencies up-to-date and secure through automation. You can read more about how to configure this action [in the docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups).

For various package ecosystems, the configuration is different. For example, `github-actions` is used for GitHub Actions workflows, `npm` for Node.js.

Then, for each package ecosystem, we specify the update schedule (i.e., how frequently Dependabot should check for updates). Additionally this PR uses `groups`, which is a feature I found recently to group the updates/PRs opened by Dependabot. Without this, every dependency update would be a separate PR (which can be quite tedious). This PR groups all `github-actions` updates together, and separates development and production dependencies for NPM.

