### PR TITLE
chore: Use --write instead of --fix for biome check

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview",
     "test": "vitest --pool=forks",
     "typecheck": "tsc",
-    "fix": "biome check --apply ."
+    "fix": "biome check --write ."
   },
   "files": ["dist"],
   "main": "./dist/chromospace.umd.cjs",


### PR DESCRIPTION
Fixes deprecation notice in `npm run fix`. Uses the preferred `--write` over `--fix`.
