### PR TITLE
feat: ability to specify target canvas in display()

### DIFF
--- a/src/chromatin.ts
+++ b/src/chromatin.ts
@@ -93,10 +93,12 @@ export type DisplayOptions = {
 export function display(
   scene: ChromatinScene,
   options: DisplayOptions,
+  targetCanvas?: HTMLCanvasElement,
 ): [ChromatinBasicRenderer, HTMLElement | HTMLCanvasElement] {
   const renderer = new ChromatinBasicRenderer({
     alwaysRedraw: options.alwaysRedraw,
     hoverEffect: options.hoverEffect,
+    canvas: targetCanvas,
   });
   buildStructures(scene.structures, renderer);
   renderer.startDrawing();


### PR DESCRIPTION
Mostly a feature needed in Gosling integration, but can imagine this comes in handy in other cases as well.

Example usage: https://observablehq.com/d/cc80aeb3e81a7528
